### PR TITLE
Add initialization note for COSMO Alpaca

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This template repository can be used for managing AppSource Apps for Business Ce
 It is a customized version of the [AL-Go-PTE](https://github.com/microsoft/AL-Go-PTE) template and is designed to be used with [COSMO Alpaca](https://cosmoconsult.com/cosmo-alpaca).
 
 > [!NOTE]
-> If this repository was created directly on GitHub, you must initialize it using the [COSMO Alpaca VS Code extension](https://marketplace.visualstudio.com/items?itemName=cosmoconsult.cosmo-alpaca). To do this, simply right-click on the repository in VS Code and select _Initialize_.
+> If you created this repository using the GitHub web UI (for example by clicking **Use this template** on GitHub.com) instead of creating it from the COSMO Alpaca VS Code extension, you must initialize it using the [COSMO Alpaca VS Code extension](https://marketplace.visualstudio.com/items?itemName=cosmoconsult.cosmo-alpaca). To do this, simply right-click on the repository in VS Code and select _Initialize_.
 
 Please go to https://aka.ms/AL-Go and [COSMO Docs](https://docs.cosmoconsult.com/en-us/cloud-service/alpaca) to learn more.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,7 @@ This template repository can be used for managing AppSource Apps for Business Ce
 
 It is a customized version of the [AL-Go-PTE](https://github.com/microsoft/AL-Go-PTE) template and is designed to be used with [COSMO Alpaca](https://cosmoconsult.com/cosmo-alpaca).
 
+> [!NOTE]
+> If this repository was created directly on GitHub, you must initialize it using the [COSMO Alpaca VS Code extension](https://marketplace.visualstudio.com/items?itemName=cosmoconsult.cosmo-alpaca). To do this, simply right-click on the repository in VS Code and select _Initialize_.
+
 Please go to https://aka.ms/AL-Go and [COSMO Docs](https://docs.cosmoconsult.com/en-us/cloud-service/alpaca) to learn more.


### PR DESCRIPTION
This pull request adds a helpful note to the `README.md` to guide users on initializing the repository when it is created directly on GitHub.

Documentation improvements:

* Added a note to the `README.md` explaining that if the repository was created directly on GitHub, it should be initialized using the COSMO Alpaca VS Code extension, with instructions on how to do this.

fixes [AB#4769](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4769)